### PR TITLE
Cleanup instances on shutdown

### DIFF
--- a/src/offspring/process.py
+++ b/src/offspring/process.py
@@ -83,6 +83,7 @@ class Subprocess(object):
             if self.TERMINATE_ON_SHUTDOWN:
                 self.process.terminate()
             self.wait()
+            while self in self._INSTANCES: self._INSTANCES.remove(self)
 
     def wait(self):
         if self.process:

--- a/src/offspring/process.py
+++ b/src/offspring/process.py
@@ -83,7 +83,8 @@ class Subprocess(object):
             if self.TERMINATE_ON_SHUTDOWN:
                 self.process.terminate()
             self.wait()
-            while self in self._INSTANCES: self._INSTANCES.remove(self)
+            while self in self._INSTANCES:
+                self._INSTANCES.remove(self)
 
     def wait(self):
         if self.process:


### PR DESCRIPTION
In the context of, https://github.com/NerdWalletOSS/kinesis-python, if multiple SubprocessLoop instances are created and and shutdown during a long running process eventually you'll hit `OSError: [Errno 24] Too many open files`. This ensures the instances are cleaned up while running.